### PR TITLE
Storyblok read hardening + links-inventory revalidation fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@ Next 16 (App Router, RSC) + Storyblok marketing-site template.
   per-story tag (`storyTag(slug)` → `storyblok:<slug>`). Never call the SDK directly
   from a component.
 - **Revalidation**: `/api/revalidate` verifies the webhook signature, then flushes
-  surgically (`revalidationTag` in `lib/storyblok-routes.ts`): a plain content
-  `published` busts only `storyblok:<full_slug>`; a `data/` global, a structural
-  action (unpublish/move/delete), or a missing slug flushes the whole `storyblok`
-  tag (nav/sitemap/links are global-tagged). Tag-flush only works because every
-  read is tagged.
+  surgically (`revalidationTags` in `lib/storyblok-routes.ts`): a plain content
+  `published` busts `storyblok:<full_slug>` plus the links inventory
+  (`storyblok:links` — a first publish adds a route only that tag can surface); a
+  `data/` global, a structural action (unpublish/move/delete), or a missing slug
+  flushes the whole `storyblok` tag. Tag-flush only works because every read is
+  tagged. Management-API publishes do NOT fire the webhook — scripted content
+  changes must call `/api/revalidate` (or redeploy) themselves.
 - **Bridge** is handled by the SDK: `<StoryblokStory>` (in `app/[[...slug]]/page.tsx`)
   renders `StoryblokLiveEditing`, which self-gates on `isVisualEditor()` and
   dynamically loads the bridge only inside the Storyblok editor iframe — so it

--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ The endpoint verifies Storyblok's `webhook-signature` header (HMAC-SHA1). In the
 Storyblok webhook settings, set the webhook secret to the same value as
 `STORYBLOK_WEBHOOK_SECRET` in your env. Requests without a valid signature are
 rejected. On a valid webhook the cache is flushed surgically: a content publish
-busts only that story's tag, while a `data/` global, a structural change
-(move/delete/unpublish), or a missing slug flushes the whole `storyblok` tag
-(which also covers nav, sitemap, and links).
+busts that story's tag plus the links inventory (so a first publish shows up in
+nav and sitemap), while a `data/` global, a structural change
+(move/delete/unpublish), or a missing slug flushes the whole `storyblok` tag.
+
+Note: publishes made through the Management API (scripts, migrations) do **not**
+fire this webhook — Storyblok only sends it for editor actions. After scripted
+content changes, call `/api/revalidate` yourself or redeploy.
 
 ### 9. Editor-managed redirects
 

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidateTag } from 'next/cache'
 import { env } from '@/lib/env'
-import { revalidationTag } from '@/lib/storyblok-routes'
+import { revalidationTags } from '@/lib/storyblok-routes'
 import { verifyWebhookSignature } from '@/lib/webhook'
 
 export async function POST(req: Request) {
@@ -19,6 +19,8 @@ export async function POST(req: Request) {
   }
 
   // Next 16 requires a cacheLife profile; 'max' is the on-demand-purge drop-in.
-  revalidateTag(revalidationTag(payload.action, payload.full_slug), 'max')
+  for (const tag of revalidationTags(payload.action, payload.full_slug)) {
+    revalidateTag(tag, 'max')
+  }
   return new Response('Revalidated', { status: 200 })
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,5 +29,9 @@ export const STORYBLOK_CACHE_TAG = 'storyblok'
 /** Per-story cache tag, so a single content publish busts only that story. */
 export const storyTag = (slug: string) => `${STORYBLOK_CACHE_TAG}:${slug}`
 
+/** Tag on the links inventory (nav, sitemap, static params). Flushed on every
+ * publish: a first publish adds a route the per-story tag can't cover. */
+export const LINKS_CACHE_TAG = `${STORYBLOK_CACHE_TAG}:links`
+
 /** Top-level Storyblok folder holding non-routable global stories. */
 export const DATA_PREFIX = 'data'

--- a/lib/storyblok-api.test.ts
+++ b/lib/storyblok-api.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { isStoryblokNotFound, resolveVersion } from './storyblok-api'
+import {
+  buildMemoCache,
+  isStoryblokNotFound,
+  memoizeDuringBuild,
+  resolveVersion,
+  withTransientRetry,
+} from './storyblok-api'
 
 const { get, draftMode } = vi.hoisted(() => ({
   get: vi.fn(),
@@ -69,6 +75,89 @@ describe('getStory failure semantics', () => {
     get.mockResolvedValue({ data: { story: { name: 'Home' } } })
     const mod = await import('./storyblok-api')
     await expect(mod.getStory('home')).resolves.toEqual({ name: 'Home' })
+  })
+})
+
+describe('withTransientRetry', () => {
+  it('retries network-level failures and 429s until success', async () => {
+    vi.useFakeTimers()
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockRejectedValueOnce({ status: 429 })
+      .mockResolvedValue('ok')
+    const promise = withTransientRetry(fn)
+    await vi.runAllTimersAsync()
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(3)
+    vi.useRealTimers()
+  })
+
+  it('passes 404 through without retrying', async () => {
+    const fn = vi.fn().mockRejectedValue({ status: 404 })
+    await expect(withTransientRetry(fn)).rejects.toEqual({ status: 404 })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries 5xx but gives up after 4 attempts', async () => {
+    vi.useFakeTimers()
+    const fn = vi.fn().mockRejectedValue({ response: { status: 502 } })
+    const promise = withTransientRetry(fn)
+    promise.catch(() => {}) // avoid unhandled rejection while timers run
+    await vi.runAllTimersAsync()
+    await expect(promise).rejects.toEqual({ response: { status: 502 } })
+    expect(fn).toHaveBeenCalledTimes(4)
+    vi.useRealTimers()
+  })
+})
+
+describe('memoizeDuringBuild', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    buildMemoCache.clear()
+  })
+
+  it('outside the build phase, fetches fresh every call', async () => {
+    vi.stubEnv('NEXT_PHASE', 'phase-production-server')
+    let calls = 0
+    const fetcher = async () => ++calls
+    await memoizeDuringBuild('k', fetcher)
+    await memoizeDuringBuild('k', fetcher)
+    expect(calls).toBe(2)
+  })
+
+  it('inside the build phase, an identical key hits the network once', async () => {
+    vi.stubEnv('NEXT_PHASE', 'phase-production-build')
+    let calls = 0
+    const fetcher = async () => ++calls
+    const [a, b] = await Promise.all([
+      memoizeDuringBuild('k', fetcher),
+      memoizeDuringBuild('k', fetcher),
+    ])
+    expect(calls).toBe(1)
+    expect(a).toBe(b)
+  })
+
+  it('inside the build phase, different keys do not share a memo entry', async () => {
+    vi.stubEnv('NEXT_PHASE', 'phase-production-build')
+    let calls = 0
+    const fetcher = async () => ++calls
+    await memoizeDuringBuild('k1', fetcher)
+    await memoizeDuringBuild('k2', fetcher)
+    expect(calls).toBe(2)
+  })
+
+  it('does not cache a rejected fetch — the next call retries', async () => {
+    vi.stubEnv('NEXT_PHASE', 'phase-production-build')
+    let calls = 0
+    const fetcher = async () => {
+      calls++
+      if (calls === 1) throw new Error('transient')
+      return 'ok'
+    }
+    await expect(memoizeDuringBuild('k', fetcher)).rejects.toThrow('transient')
+    await expect(memoizeDuringBuild('k', fetcher)).resolves.toBe('ok')
+    expect(calls).toBe(2)
   })
 })
 

--- a/lib/storyblok-api.ts
+++ b/lib/storyblok-api.ts
@@ -3,7 +3,7 @@ import { ISbStoryData } from '@storyblok/react/rsc'
 import StoryblokClient from 'storyblok-js-client'
 import { unstable_cache } from 'next/cache'
 import { draftMode } from 'next/headers'
-import { isPreview, STORYBLOK_CACHE_TAG, storyTag } from './config'
+import { isPreview, LINKS_CACHE_TAG, STORYBLOK_CACHE_TAG, storyTag } from './config'
 import { env } from './env'
 import { getStoryblokApi } from './storyblok'
 
@@ -18,9 +18,63 @@ export function resolveVersion(isDraft: boolean): 'draft' | 'published' {
 let previewClient: StoryblokClient | null = null
 function getPreviewClient(): StoryblokClient {
   if (!previewClient) {
-    previewClient = new StoryblokClient({ accessToken: env.STORYBLOK_PREVIEW_TOKEN })
+    // Draft mode refetches everything per request (no cross-request cache by
+    // design), so bursts hit the preview token's ~3 req/s limit and exhaust
+    // the SDK's default retries → error page. Throttle client-side instead.
+    previewClient = new StoryblokClient({
+      accessToken: env.STORYBLOK_PREVIEW_TOKEN,
+      rateLimit: 3,
+      maxRetries: 10,
+    })
   }
   return previewClient
+}
+
+function isBuildPhase(): boolean {
+  return process.env.NEXT_PHASE === 'phase-production-build'
+}
+
+/** Exported for tests. */
+export const buildMemoCache = new Map<string, Promise<unknown>>()
+
+/**
+ * Draft reads can't change mid-build, so share one fetch per key per worker —
+ * per-request otherwise, since the visual editor needs live drafts.
+ */
+export function memoizeDuringBuild<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  if (!isBuildPhase()) return fetcher()
+  const cached = buildMemoCache.get(key)
+  if (cached) return cached as Promise<T>
+  const promise = fetcher()
+  buildMemoCache.set(key, promise)
+  promise.catch(() => buildMemoCache.delete(key))
+  return promise
+}
+
+function httpStatus(error: unknown): number | undefined {
+  const e = error as { status?: number; response?: { status?: number } } | undefined
+  return e?.status ?? e?.response?.status
+}
+
+/**
+ * Retry reads that die below HTTP (fetch failed, socket reset) or after the
+ * SDK exhausts its 429 retries. The SDK absorbs rate limits itself, but a
+ * single network-level failure rethrows immediately — and during a static
+ * export that one throw kills the whole build. 404 and other client errors
+ * pass through untouched (a 404 misread as transient would retry real misses).
+ * Exported for tests.
+ */
+export async function withTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      const status = httpStatus(error)
+      const transient = status === undefined || status === 429 || status >= 500
+      if (!transient || attempt >= 4) throw error
+      await new Promise(resolve => setTimeout(resolve, 500 * attempt))
+    }
+  }
 }
 
 // Built per-slug so the webhook can bust one story without flushing the rest.
@@ -28,10 +82,12 @@ function fetchPublishedStory(slug: string) {
   return unstable_cache(
     async () => {
       const api = getStoryblokApi()
-      const { data } = await api.get(`cdn/stories/${slug}`, {
-        version: 'published',
-        resolve_links: 'url',
-      })
+      const { data } = await withTransientRetry(() =>
+        api.get(`cdn/stories/${slug}`, {
+          version: 'published',
+          resolve_links: 'url',
+        })
+      )
       return data.story
     },
     ['storyblok-story', slug],
@@ -46,11 +102,15 @@ export async function getStory<T>(slug: string): Promise<ISbStoryData<T> | null>
   try {
     if (version === 'draft') {
       const api = getPreviewClient()
-      const { data } = await api.get(`cdn/stories/${slug}`, {
-        version: 'draft',
-        resolve_links: 'url',
-        cv: Date.now(),
-      })
+      const { data } = await memoizeDuringBuild(`storyblok-story-draft:${slug}`, () =>
+        withTransientRetry(() =>
+          api.get(`cdn/stories/${slug}`, {
+            version: 'draft',
+            resolve_links: 'url',
+            cv: Date.now(),
+          })
+        )
+      )
       return data.story as ISbStoryData<T>
     }
     return (await fetchPublishedStory(slug)) as ISbStoryData<T>
@@ -61,19 +121,17 @@ export async function getStory<T>(slug: string): Promise<ISbStoryData<T> | null>
 }
 
 export function isStoryblokNotFound(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false
-  const candidate = error as { status?: unknown; response?: { status?: unknown } }
-  return candidate.status === 404 || candidate.response?.status === 404
+  return httpStatus(error) === 404
 }
 
 const fetchLinks = unstable_cache(
   async () => {
     const api = getStoryblokApi()
-    const { data } = await api.get('cdn/links/', { version: 'published' })
+    const { data } = await withTransientRetry(() => api.get('cdn/links/', { version: 'published' }))
     return data.links as Record<string, SbLink>
   },
   ['storyblok-links'],
-  { tags: [STORYBLOK_CACHE_TAG] }
+  { tags: [STORYBLOK_CACHE_TAG, LINKS_CACHE_TAG] }
 )
 
 export async function getAllLinks(): Promise<Record<string, SbLink>> {

--- a/lib/storyblok-routes.test.ts
+++ b/lib/storyblok-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isDataRoute, revalidationTag } from './storyblok-routes'
+import { isDataRoute, revalidationTags } from './storyblok-routes'
 
 describe('isDataRoute', () => {
   it('flags the data folder root', () => {
@@ -16,21 +16,24 @@ describe('isDataRoute', () => {
   })
 })
 
-describe('revalidationTag', () => {
-  it('busts only the story on a content publish', () => {
-    expect(revalidationTag('published', 'about')).toBe('storyblok:about')
-    expect(revalidationTag('published', 'home')).toBe('storyblok:home')
+describe('revalidationTags', () => {
+  it('busts the story and the links inventory on a content publish', () => {
+    expect(revalidationTags('published', 'about')).toEqual(['storyblok:about', 'storyblok:links'])
+    expect(revalidationTags('published', 'home')).toEqual(['storyblok:home', 'storyblok:links'])
+  })
+  it('normalizes the trailing slash of folder startpages', () => {
+    expect(revalidationTags('published', 'about/')).toEqual(['storyblok:about', 'storyblok:links'])
   })
   it('flushes everything for a data/ global', () => {
-    expect(revalidationTag('published', 'data/menu')).toBe('storyblok')
+    expect(revalidationTags('published', 'data/menu')).toEqual(['storyblok'])
   })
   it('flushes everything for structural actions', () => {
-    expect(revalidationTag('moved', 'about')).toBe('storyblok')
-    expect(revalidationTag('deleted', 'about')).toBe('storyblok')
-    expect(revalidationTag('unpublished', 'about')).toBe('storyblok')
+    expect(revalidationTags('moved', 'about')).toEqual(['storyblok'])
+    expect(revalidationTags('deleted', 'about')).toEqual(['storyblok'])
+    expect(revalidationTags('unpublished', 'about')).toEqual(['storyblok'])
   })
   it('flushes everything when the slug is missing', () => {
-    expect(revalidationTag('published', undefined)).toBe('storyblok')
-    expect(revalidationTag(undefined, undefined)).toBe('storyblok')
+    expect(revalidationTags('published', undefined)).toEqual(['storyblok'])
+    expect(revalidationTags(undefined, undefined)).toEqual(['storyblok'])
   })
 })

--- a/lib/storyblok-routes.ts
+++ b/lib/storyblok-routes.ts
@@ -1,14 +1,23 @@
-import { DATA_PREFIX, STORYBLOK_CACHE_TAG, storyTag } from './config'
+import { DATA_PREFIX, LINKS_CACHE_TAG, STORYBLOK_CACHE_TAG, storyTag } from './config'
 
 /** True if a slug is the data/ globals folder or a story inside it. */
 export function isDataRoute(slug: string): boolean {
   return slug === DATA_PREFIX || slug.startsWith(`${DATA_PREFIX}/`)
 }
 
-/** Webhook flush target: a content publish busts one story, anything else
- * (data/ global, structural action, missing slug) busts the global tag. */
-export function revalidationTag(action?: string, fullSlug?: string): string {
-  return action === 'published' && fullSlug && !isDataRoute(fullSlug)
-    ? storyTag(fullSlug)
-    : STORYBLOK_CACHE_TAG
+/**
+ * Cache tags to flush for a Storyblok webhook. A content publish busts that
+ * story plus the links inventory — a first publish adds a route only the links
+ * tag can surface. Anything else (data/ global, unpublish/move/delete, missing
+ * slug) flushes the global tag.
+ *
+ * Folder startpages arrive with a trailing slash but are read without one, so
+ * the slug is normalized or the flush silently no-ops.
+ */
+export function revalidationTags(action?: string, fullSlug?: string): string[] {
+  const slug = fullSlug?.replace(/\/+$/, '')
+  if (action === 'published' && slug && !isDataRoute(slug)) {
+    return [storyTag(slug), LINKS_CACHE_TAG]
+  }
+  return [STORYBLOK_CACHE_TAG]
 }

--- a/lib/storyblok.ts
+++ b/lib/storyblok.ts
@@ -9,6 +9,9 @@ import teaser from '@/components/nestables/Teaser'
 export const getStoryblokApi = storyblokInit({
   accessToken: env.NEXT_PUBLIC_STORYBLOK_TOKEN,
   use: [apiPlugin],
+  // Build workers burst past the published token's req/s cap (429 storms in
+  // the build log); throttle client-side and out-retry the residual limits.
+  apiOptions: { rateLimit: 4, maxRetries: 10 },
   components: {
     page,
     feature,


### PR DESCRIPTION
Ports the battle-tested resilience work from fgpfister.ch (their PR #36) and fixes a revalidation staleness bug it surfaced.

## Read hardening
- Both clients now throttle below their token's req/s cap (published 4/s, preview 3/s) with `maxRetries: 10` — previously bare `accessToken`-only construction, so a 429 during build threw.
- `withTransientRetry` wraps every read: retries what the SDK rethrows immediately (network-level failures, exhausted 429s, 5xx) with linear backoff, 4 attempts. 404 and other client errors pass through untouched — a 404 misread as transient would retry real misses.
- `memoizeDuringBuild` shares one draft fetch per key per build worker; preview-deploy builds refetched `data/` globals per route. No-op outside the build phase (the visual editor needs live drafts).

## Revalidation fix
A first publish adds a route, but the webhook only busted `storyblok:<slug>` — nav, sitemap, and static params (served from the globally-tagged links cache) stayed stale until an unrelated global flush. Now:
- `fetchLinks` carries its own `storyblok:links` tag; a content publish flushes `[storyTag(slug), LINKS_CACHE_TAG]` (`revalidationTag` → `revalidationTags`, returning a list).
- Folder-startpage slugs arrive with a trailing slash but are read without one — normalized before tagging, else the flush silently no-ops.
- Docs: Management-API publishes fire no webhook; scripted content changes must revalidate or redeploy themselves.

Deliberately not ported: per-content-type `listTag` (the template has no listings — zero readers), redirects proxy variant and image loader (recorded counter-decisions).

`yarn check` green: formatting, ESLint, TS, 61 tests, type drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)