### PR TITLE
fix(links): resolve the root story to / instead of /home

### DIFF
--- a/lib/getHref.test.ts
+++ b/lib/getHref.test.ts
@@ -3,32 +3,48 @@ import type { StoryblokMultilink } from '@/.storyblok/types/storyblok'
 import { getHref } from './getHref'
 
 const link = (o: Partial<StoryblokMultilink>) => o as StoryblokMultilink
+const story = (o: Partial<StoryblokMultilink>) => link({ linktype: 'story', ...o })
 
 describe('getHref', () => {
   it('resolves a story link by full_slug', () => {
     expect(
-      getHref(
-        link({
-          linktype: 'story',
-          story: { full_slug: 'about/team' } as never,
-          cached_url: 'about/team',
-        })
-      )
+      getHref(story({ story: { full_slug: 'about/team' } as never, cached_url: 'about/team' }))
     ).toBe('/about/team')
   })
+
   it('falls back to cached_url when the story is not resolved', () => {
-    expect(getHref(link({ linktype: 'story', cached_url: 'about' }))).toBe('/about')
+    expect(getHref(story({ cached_url: 'about' }))).toBe('/about')
   })
+
   it('appends an anchor to story links', () => {
-    expect(getHref(link({ linktype: 'story', cached_url: 'home', anchor: 'cta' }))).toBe(
-      '/home#cta'
-    )
+    expect(getHref(story({ cached_url: 'about', anchor: 'cta' }))).toBe('/about#cta')
   })
+
   it('resolves url, asset, and email links', () => {
     expect(getHref(link({ linktype: 'url', url: 'https://x.com' }))).toBe('https://x.com')
     expect(getHref(link({ linktype: 'asset', url: 'https://a.com/f.pdf' }))).toBe(
       'https://a.com/f.pdf'
     )
     expect(getHref(link({ linktype: 'email', email: 'a@b.ch' }))).toBe('mailto:a@b.ch')
+  })
+
+  describe('the root story', () => {
+    it('is / and never /home, which is a reachable duplicate the sitemap omits', () => {
+      expect(getHref(story({ cached_url: 'home' }))).toBe('/')
+      expect(getHref(story({ story: { full_slug: 'home' } as never }))).toBe('/')
+    })
+
+    it('keeps a leading slash before an anchor, never a bare fragment', () => {
+      expect(getHref(story({ cached_url: 'home', anchor: 'cta' }))).toBe('/#cta')
+    })
+
+    it('handles the trailing slash Storyblok sends for folder startpages', () => {
+      expect(getHref(story({ cached_url: 'home/' }))).toBe('/')
+      expect(getHref(story({ cached_url: 'about/' }))).toBe('/about')
+    })
+
+    it('does not special-case a story merely named home inside a folder', () => {
+      expect(getHref(story({ cached_url: 'about/home' }))).toBe('/about/home')
+    })
   })
 })

--- a/lib/getHref.ts
+++ b/lib/getHref.ts
@@ -1,15 +1,31 @@
 import { StoryblokMultilink } from '@/.storyblok/types/storyblok'
 
+/**
+ * Path for a story slug. The root story is `home` in Storyblok but `/` on the
+ * site — the sitemap and the page's own canonical both say `/`, so a link
+ * built as `/home` points at a reachable duplicate the sitemap disowns.
+ *
+ * Only the exact root slug is special: a story genuinely at `about/home` keeps
+ * its path. Storyblok sends folder startpages with a trailing slash, so the
+ * slug is normalized before comparing.
+ */
+function storyPath(slug: string): string {
+  const normalized = slug.replace(/\/+$/, '')
+  return normalized === 'home' ? '' : `/${normalized}`
+}
+
 export function getHref(link: StoryblokMultilink): string {
   const anchor = link.anchor ? `#${link.anchor}` : ''
 
   switch (link.linktype) {
-    case 'story':
-      if (!link.story || !('full_slug' in link.story)) {
-        return `/${link.cached_url}${anchor}`
-      }
-
-      return `/${link.story.full_slug}${anchor}`
+    case 'story': {
+      const slug =
+        link.story && 'full_slug' in link.story ? link.story.full_slug : (link.cached_url ?? '')
+      // `/` before the anchor, or an anchor on the home story would render as a
+      // bare `#cta`, which resolves against whatever page the link sits on.
+      const path = storyPath(slug) || '/'
+      return `${path}${anchor}`
+    }
     case 'url':
     case 'asset':
       return link.url

--- a/lib/getHref.ts
+++ b/lib/getHref.ts
@@ -1,14 +1,6 @@
 import { StoryblokMultilink } from '@/.storyblok/types/storyblok'
 
-/**
- * Path for a story slug. The root story is `home` in Storyblok but `/` on the
- * site — the sitemap and the page's own canonical both say `/`, so a link
- * built as `/home` points at a reachable duplicate the sitemap disowns.
- *
- * Only the exact root slug is special: a story genuinely at `about/home` keeps
- * its path. Storyblok sends folder startpages with a trailing slash, so the
- * slug is normalized before comparing.
- */
+/** The root story is `home` in Storyblok but `/` on the site; `about/home` is not. */
 function storyPath(slug: string): string {
   const normalized = slug.replace(/\/+$/, '')
   return normalized === 'home' ? '' : `/${normalized}`
@@ -21,8 +13,7 @@ export function getHref(link: StoryblokMultilink): string {
     case 'story': {
       const slug =
         link.story && 'full_slug' in link.story ? link.story.full_slug : (link.cached_url ?? '')
-      // `/` before the anchor, or an anchor on the home story would render as a
-      // bare `#cta`, which resolves against whatever page the link sits on.
+      // `/` before the anchor, or the root story's would render as a bare `#cta`.
       const path = storyPath(slug) || '/'
       return `${path}${anchor}`
     }


### PR DESCRIPTION
Independent of #38/#39/#40 — branched from `main`, touches only `lib/getHref.ts`.

## The bug

`getHref` returned `/${cached_url}`, so every internal link to the root story rendered as **`/home`**.

Confirmed against a built server:

```
/       200
/home   200   ← serves the home page
sitemap  → lists only /
```

So internal links pointed at a reachable duplicate the sitemap disowns. Both URLs already declare `/` as canonical, so this was never an indexing bug — but the links were wrong, and `getHref` was the odd one out: `sitemapPaths` and the page's own canonical already agreed on `/`.

## The fix

- Only the **exact** root slug is special-cased — a story genuinely at `about/home` keeps its path.
- Storyblok sends folder startpages with a trailing slash, so the slug is normalized before comparing (`home/` → `/`).
- An anchor on the root story now renders **`/#cta`, not `#cta`** — a bare fragment resolves against whatever page the link sits on. I got this wrong in my first pass; the test caught it.

## Verification

Three of the new tests fail against the previous implementation and pass against this one:

```
AssertionError: expected '/home'     to be '/'
AssertionError: expected '/home#cta' to be '/#cta'
AssertionError: expected '/home/'    to be '/'
```

`yarn check` green — 101 tests. Rendered hrefs on a built server contain no `/home`.

## On the trailing-`?` bug

**It does not exist in this template.** brillen-werk.ch `63c8e95` fixed `getHref` appending `?${searchParams}` unconditionally — 16 links per page rendering as `/sehtest?`. That came from an `sp_location` query feature this template has no equivalent of; its `getHref` builds no query string at all.

The nearest equivalent here, `withQuery` in `lib/redirects.ts`, already guards on an empty query (`if (!query) return destination`) and `lib/redirects.test.ts:79` already covers it. No change needed.

## Not fixed here

`/home` still resolves 200. The canonical tag and the sitemap both handle it correctly, so this is cosmetic now that nothing links there — but a `redirects()` entry in `next.config.mjs` would close it if you want the URL gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)